### PR TITLE
Proper way to delete directories in ansible

### DIFF
--- a/roles/nodes/tasks/main.yml
+++ b/roles/nodes/tasks/main.yml
@@ -13,6 +13,8 @@
 - name: iptables 49152
   command: iptables -A HEKETI -p tcp -m state --state NEW -m multiport --dports 49152:49251 -j ACCEPT
 
+- file: path=/etc/kubernetes/manifests state=absent
+
 - name: join with master
   command: kubeadm join --token={{ kubernetes_token }} {{ hostvars['master'].ansible_eth1.ipv4.address }}
 


### PR DESCRIPTION
This fixes the issues with the /etc/kubernetes/manifests directory breaking the deployment